### PR TITLE
Add beefy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5843,6 +5843,9 @@ dependencies = [
 name = "parachain-template-node"
 version = "0.1.0"
 dependencies = [
+ "beefy-gadget",
+ "beefy-gadget-rpc",
+ "beefy-primitives",
  "clap",
  "cumulus-client-cli",
  "cumulus-client-collator",
@@ -5895,6 +5898,7 @@ dependencies = [
  "sp-core 6.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.28)",
  "sp-inherents 4.0.0-dev (git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.28)",
  "sp-keystore 0.12.0 (git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.28)",
+ "sp-mmr-primitives",
  "sp-offchain",
  "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.28)",
  "sp-session",
@@ -5911,6 +5915,7 @@ dependencies = [
 name = "parachain-template-runtime"
 version = "0.1.0"
 dependencies = [
+ "beefy-primitives",
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",
  "cumulus-pallet-parachain-system",
@@ -5932,7 +5937,10 @@ dependencies = [
  "pallet-aura",
  "pallet-authorship",
  "pallet-balances",
+ "pallet-beefy",
+ "pallet-beefy-mmr",
  "pallet-collator-selection",
+ "pallet-mmr",
  "pallet-session",
  "pallet-sudo",
  "pallet-timestamp",
@@ -5952,6 +5960,7 @@ dependencies = [
  "sp-core 6.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.28)",
  "sp-inherents 4.0.0-dev (git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.28)",
  "sp-io 6.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.28)",
+ "sp-mmr-primitives",
  "sp-offchain",
  "sp-runtime 6.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.28)",
  "sp-session",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -32,6 +32,8 @@ jsonrpsee = { version = "0.15.1", features = ["server"] }
 parachain-template-runtime = { path = "../runtime" }
 
 # Substrate Dependencies
+beefy-gadget = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.28" }
+beefy-gadget-rpc = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.28" }
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.28" }
 frame-benchmarking-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.28" }
 
@@ -61,6 +63,7 @@ sc-transaction-pool-api = { git = "https://github.com/paritytech/substrate", bra
 sc-tracing = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.28" }
 
 ## Substrate Primitive Dependencies
+beefy-primitives = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.28" }
 sp-api = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.28" }
 sp-block-builder = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.28" }
 sp-blockchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.28" }
@@ -70,6 +73,7 @@ sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-
 sp-inherents = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.28" }
 sp-keystore = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.28" }
 sp-offchain = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.28" }
+sp-mmr-primitives = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.28" }
 sp-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.28" }
 sp-session = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.28" }
 sp-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.28" }
@@ -85,9 +89,9 @@ cumulus-client-network = { git = 'https://github.com/paritytech/cumulus', branch
 cumulus-client-service = { git = 'https://github.com/paritytech/cumulus', branch = 'polkadot-v0.9.28' }
 cumulus-primitives-core = { git = 'https://github.com/paritytech/cumulus', branch = 'polkadot-v0.9.28' }
 cumulus-primitives-parachain-inherent = { git = 'https://github.com/paritytech/cumulus', branch = 'polkadot-v0.9.28' }
-cumulus-relay-chain-inprocess-interface = { git = "https://github.com/paritytech/cumulus.git", branch = "polkadot-v0.9.28" }
-cumulus-relay-chain-interface = { git = "https://github.com/paritytech/cumulus.git", branch = "polkadot-v0.9.28" }
-cumulus-relay-chain-rpc-interface = { git = "https://github.com/paritytech/cumulus.git", branch = "polkadot-v0.9.28" }
+cumulus-relay-chain-inprocess-interface = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.28" }
+cumulus-relay-chain-interface = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.28" }
+cumulus-relay-chain-rpc-interface = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.28" }
 
 # Polkadot dependencies
 polkadot-cli = { git = "https://github.com/paritytech/polkadot", branch = "release-v0.9.28" }

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -19,6 +19,16 @@ use sp_blockchain::{Error as BlockChainError, HeaderBackend, HeaderMetadata};
 /// A type representing all RPC extensions.
 pub type RpcExtension = jsonrpsee::RpcModule<()>;
 
+/// Dependencies for BEEFY
+pub struct BeefyDeps {
+	/// Receives notifications about finality proof events from BEEFY.
+	pub beefy_finality_proof_stream: beefy_gadget::notification::BeefyVersionedFinalityProofStream<Block>,
+	/// Receives notifications about best block events from BEEFY.
+	pub beefy_best_block_stream: beefy_gadget::notification::BeefyBestBlockStream<Block>,
+	/// Executor to drive the subscription manager in the BEEFY RPC handler.
+	pub subscription_executor: sc_rpc::SubscriptionTaskExecutor,
+}
+
 /// Full client dependencies
 pub struct FullDeps<C, P> {
 	/// The client instance to use.
@@ -27,6 +37,8 @@ pub struct FullDeps<C, P> {
 	pub pool: Arc<P>,
 	/// Whether to deny unsafe calls
 	pub deny_unsafe: DenyUnsafe,
+	/// BEEFY specific dependencies.
+	pub beefy: BeefyDeps,
 }
 
 /// Instantiate all RPC extensions.
@@ -43,16 +55,26 @@ where
 		+ 'static,
 	C::Api: pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>,
 	C::Api: substrate_frame_rpc_system::AccountNonceApi<Block, AccountId, Nonce>,
+	C::Api: pallet_mmr_rpc::MmrRuntimeApi<Block, <Block as sp_runtime::traits::Block>::Hash>,
 	C::Api: BlockBuilder<Block>,
 	P: TransactionPool + Sync + Send + 'static,
 {
 	use pallet_transaction_payment_rpc::{TransactionPayment, TransactionPaymentApiServer};
 	use substrate_frame_rpc_system::{System, SystemApiServer};
+	use beefy_gadget_rpc::{Beefy, BeefyApiServer};
 
 	let mut module = RpcExtension::new(());
-	let FullDeps { client, pool, deny_unsafe } = deps;
+	let FullDeps { client, pool, deny_unsafe, beefy } = deps;
 
 	module.merge(System::new(client.clone(), pool, deny_unsafe).into_rpc())?;
 	module.merge(TransactionPayment::new(client).into_rpc())?;
+	module.merge(
+		Beefy::<Block>::new(
+			beefy.beefy_finality_proof_stream,
+			beefy.beefy_best_block_stream,
+			beefy.subscription_executor,
+		)?
+		.into_rpc(),
+	)?;
 	Ok(module)
 }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -24,6 +24,7 @@ smallvec = "1.6.1"
 
 # Substrate Dependencies
 ## Substrate Primitive Dependencies
+beefy-primitives = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.28" }
 sp-api = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.28" }
 sp-block-builder = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.28" }
 sp-consensus-aura = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.28" }
@@ -31,6 +32,7 @@ sp-core = { git = "https://github.com/paritytech/substrate", default-features = 
 sp-inherents = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.28" }
 sp-io = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.28" }
 sp-offchain = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.28" }
+sp-mmr-primitives = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.28" }
 sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.28" }
 sp-session = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.28" }
 sp-std = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.28" }
@@ -50,6 +52,9 @@ frame-try-runtime = { git = "https://github.com/paritytech/substrate", default-f
 pallet-aura = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.28" }
 pallet-authorship = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.28" }
 pallet-balances = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.28" }
+pallet-beefy = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.28" }
+pallet-beefy-mmr = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.28" }
+pallet-mmr = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.28" }
 pallet-session = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.28" }
 pallet-sudo = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.28" }
 pallet-timestamp = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.28" }
@@ -82,10 +87,8 @@ default = [
 	"std",
 ]
 std = [
+	"beefy-primitives/std",
 	"codec/std",
-	"log/std",
-	"scale-info/std",
-	"serde",
 	"cumulus-pallet-aura-ext/std",
 	"cumulus-pallet-dmp-queue/std",
 	"cumulus-pallet-parachain-system/std",
@@ -98,10 +101,14 @@ std = [
 	"frame-support/std",
 	"frame-system-rpc-runtime-api/std",
 	"frame-system/std",
+	"log/std",
+	"log/std",
 	"pallet-aura/std",
 	"pallet-authorship/std",
 	"pallet-balances/std",
+	"pallet-beefy/std",
 	"pallet-collator-selection/std",
+	"pallet-mmr/std",
 	"pallet-session/std",
 	"pallet-sudo/std",
 	"pallet-timestamp/std",
@@ -111,12 +118,15 @@ std = [
 	"parachain-info/std",
 	"polkadot-parachain/std",
 	"polkadot-runtime-common/std",
+	"scale-info/std",
+	"serde",
 	"sp-api/std",
 	"sp-block-builder/std",
 	"sp-consensus-aura/std",
 	"sp-core/std",
 	"sp-inherents/std",
 	"sp-io/std",
+	"sp-mmr-primitives/std",
 	"sp-offchain/std",
 	"sp-runtime/std",
 	"sp-session/std",

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -7,6 +7,7 @@
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
 mod weights;
+mod migrations;
 pub mod xcm_config;
 
 use smallvec::smallvec;
@@ -115,6 +116,7 @@ pub type Executive = frame_executive::Executive<
 	frame_system::ChainContext<Runtime>,
 	Runtime,
 	AllPalletsWithSystem,
+	migrations::Migrations,
 >;
 
 /// Handles converting a weight scalar to a fee value, based on the scale and granularity of the

--- a/runtime/src/migrations.rs
+++ b/runtime/src/migrations.rs
@@ -1,0 +1,40 @@
+use frame_support::{traits::OnRuntimeUpgrade, weights::Weight};
+use sp_core::ecdsa;
+use sp_runtime::impl_opaque_keys;
+use sp_std::vec::Vec;
+
+use crate::RuntimeBlockWeights;
+use crate::{AccountId, Aura, BeefyId, Session};
+
+pub type Migrations = SessionKeysMigration;
+
+impl_opaque_keys! {
+	pub struct SessionKeysOld {
+		pub aura: Aura,
+	}
+}
+
+/// Generates a `BeefyId` from the given `AccountId`. The resulting `BeefyId` is
+/// a dummy value and this is a utility function meant to be used when migration
+/// session keys.
+pub fn dummy_beefy_id_from_account_id(a: AccountId) -> BeefyId {
+	let mut id_raw = [0u8; 33];
+
+	// NOTE: AccountId is 32 bytes, whereas BeefyId is 33 bytes.
+	id_raw[1..].copy_from_slice(a.as_ref());
+	id_raw[0..4].copy_from_slice(b"beef");
+
+	ecdsa::Public(id_raw).into()
+}
+
+pub struct SessionKeysMigration;
+
+impl OnRuntimeUpgrade for SessionKeysMigration {
+	fn on_runtime_upgrade() -> Weight {
+		Session::upgrade_keys::<SessionKeysOld, _>(|id, keys| crate::SessionKeys {
+			aura: keys.aura,
+			beefy: dummy_beefy_id_from_account_id(id),
+		});
+		RuntimeBlockWeights::get().max_block
+	}
+}


### PR DESCRIPTION
After a runtime upgrade blocks are going to contain BEEFY logs, but it doesn't mean it works properly.
1. Start network without BEEFY
2. Upgrade the node binary
3. Make runtime upgrade
4. Check "Storage session.queuedKeys". It must have dummy beefy keys
5. Wait until the session is ended.
6. Check "Storage session.authorities". It must be equal to beefy keys from the step 4.
7 (Optional). RPC author.insertKey(aura, <seed phrase>, <public key>) # 1
8. RPC author.insertKey(beef, <seed phrase>, <public key>) # 2
9. Call extrinsic session.setKeys(0x + <aura key> + <beefy key>, 0x00) with collator (ALICE) # 3
10. Check "Storage session.nextKeys". It must be equal to the provided keys.
11. Restart the collator node. ? Funny how it doesn't work here.
12. Wait until the session is ended.
13. Check "Storage session.queuedKeys" and "Storage beefy.nextAuthorities". It must have the new beefy key.
14. Wait until the session is ended.
15. Check "Storage beefy.authorities". It must have the new beefy key.
16. Wait until the session is ended.
16. Restart the collator node.
17. Make enough of collators have done it.
18. Check the collators' console. It must have `Round #350 concluded, finality_proof: V1(SignedCommitment { commitment: Commitment { payload: Payload([([109, 104], [157, 47, 48, 178, 94, 25, 99, 15, 217, 74, 254, 122, 208, 134, 90, 147, 2, 128, 224, 10, 27, 137, 111, 237, 91, 16, 59, 157, 60, 87, 175, 242])]), block_number: 350, validator_set_id: 14 }, signatures: [Some(Signature(fc4869d42009f3e1e45afd8c4fdd09672dff4141244af41a8a317a93364513153d0db7ac92906ae7cb0a566cabd25952512e8fa297a5ad6365b2268e4c6114cd00)), Some(Signature(1b1a5400cf4bfa25d66bd6f3252b42b838384b57ec8423fdaf767c7a9b4541891972ea13f2a3b84113eefeb7f04cb7aadb1957dd87e574e999763dde8ba8f3b301))] }).`

# 1
`<seed phrase>` = //Alice
`<public key>` = 0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d
```
polkadot key inspect --network sora_kusama_para '//Alice'
Secret Key URI `//Alice` is account:
  Network ID:        sora_kusama_para
 Secret seed:       0xe5be9a5092b81bca64be81d212e7f2f9eba183bb7a90954f7b76361f6edb5c0a
  Public key (hex):  0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d
  Account ID:        0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d
  Public key (SS58): oFGTjPNn92ZvzrWyP5BQtNqGJ33CtGCqM33BQRuNEkm7KHd4v
  SS58 Address:      oFGTjPNn92ZvzrWyP5BQtNqGJ33CtGCqM33BQRuNEkm7KHd4v
```
# 2
`<seed phrase>` = //Alice
`<public key>` = 0x020a1091341fe5664bfa1782d5e04779689068c916b04cb365ec3153755684d9a1
```
polkadot key inspect --network sora_kusama_para '//Alice' --scheme ecdsa
Secret Key URI `//Alice` is account:
  Network ID:        sora_kusama_para
 Secret seed:       0xcb6df9de1efca7a3998a8ead4e02159d5fa99c3e0d4fd6432667390bb4726854
  Public key (hex):  0x020a1091341fe5664bfa1782d5e04779689068c916b04cb365ec3153755684d9a1
  Account ID:        0x01e552298e47454041ea31273b4b630c64c104e4514aa3643490b8aaca9cf8ed
  Public key (SS58): 4X7cGgWSf5z3wKyVjs9m3fsYrJNXWVQWT17WGiZVKTQijBPezLn
  SS58 Address:      oFBhyVMdmTBPJkiYJFnjTtXYekMwQzTRYQ7KjZiqifPTPT5Vm
```
# 3
Given aura key is `0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d` and beefy key is `0x020a1091341fe5664bfa1782d5e04779689068c916b04cb365ec3153755684d9a1`, keys is `0x` + `d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d` + `020a1091341fe5664bfa1782d5e04779689068c916b04cb365ec3153755684d9a1`
Proof can be anything at the moment.