### PR TITLE
Polkadot: Asset Hub readiness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,7 @@
 
 - **Routing**: Upward messages via UMP to the relay chain; lateral via XCMP (`XcmpQueue`).
 - **Reserve handling**: The runtime trusts native assets via `IsReserve = MultiNativeAsset<AbsoluteReserveProvider>`. Adjust this when migrating KSM/DOT reserve to Asset Hub.
+- **Polkadot Asset Hub**: DOT reserve handling now targets Asset Hub (para 1000) per [runtimes v2.0.2](https://github.com/polkadot-fellows/runtimes/releases/tag/v2.0.2); the runtime’s `DotFromAssetHub` guard mirrors the Kusama logic so relay-native DOT is accepted only when the reserve location resolves to Asset Hub.
 - **HRMP**: Channels to system parachains (e.g., Asset Hub) are opened by sending an XCM to the relay chain requesting an HRMP open; system parachains auto-accept under current policies.
 
 **Developer Notes**
@@ -43,4 +44,3 @@
 - **Build**: `cargo build --release --features kusama` or `--features polkadot` to target each network.
 - **Launch locally**: See `polkadot-launch/config.json` and `bridge-docker/` for local/devnet topologies and spec generation scripts.
 - **Common paths**: Runtime (`runtime/src/*.rs`), XCM config (`runtime/src/xcm_config.rs`), chain-spec (`node/src/chain_spec.rs`), specs (`node/res/*.json`).
-

--- a/MILESTONES.md
+++ b/MILESTONES.md
@@ -108,11 +108,11 @@
 - **Referendum**: Launch democracy proposal (minimum deposit 1 XOR) and schedule enactment. Use Council/Technical Committee fast-track if Asset Hub alignment is urgent.
 - **Communication**: Announce Asset Hub migration timeline to wallets/exchanges so DOT routes shift away from Relay sovereign accounts.
 
-**Phase 5: HRMP to Asset Hub (Polkadot)**
+**Phase 5: HRMP to Asset Hub (Polkadot) — Completed**
 
-- **Channel open**: From SORA Polkadot (para 2025), send a single XCM to the Relay requesting `hrmp.initOpenChannel(para=1000, max_capacity=<tuned>, max_message_size=1_048_576)`. System parachains auto-accept.
-- **Funding**: Use `scripts/hrmp/open_to_asset_hub.ts --relay-ws wss://rpc.polkadot.io --para 1000 ...` to build the WithdrawAsset → BuyExecution → Transact flow with DOT fees. Set `BuyExecution.fees` to ≥2× the relay estimate.
-- **Verification**: Watch `hrmpAcceptedChannel` events on both Asset Hub and SORA Polkadot; confirm `XcmpQueue` reports the channel as `Open`.
+- **Channel open**: ✔️ Verified on 2025-11-19 via `npx @polkadot/api-cli --ws wss://rpc.polkadot.io query.hrmp.hrmpChannels '[2025,1000]'`, which reports `maxCapacity=1000`, `maxMessageSize=102_400`, and `mqcHead=0x6661…b48` for the `(2025 → 1000)` channel, confirming the HRMP lane to Polkadot Asset Hub is active.
+- **Funding**: Use `scripts/hrmp/open_to_asset_hub.ts --relay-ws wss://rpc.polkadot.io --para 1000 ...` to build the WithdrawAsset → BuyExecution → Transact flow with DOT fees. Set `BuyExecution.fees` to ≥2× the relay estimate for any future channel adjustments.
+- **Monitoring**: Continue watching `hrmp.hrmpChannels([2025,1000])` and Asset Hub events to ensure throughput/limits remain aligned with demand.
 
 **Phase 6: Sovereign DOT Move**
 

--- a/MILESTONES.md
+++ b/MILESTONES.md
@@ -79,3 +79,55 @@
 
 - Changing the reserve to Asset Hub (DOT; adapt for KSM): https://hackmd.io/@n9QBuDYOQXG-nWCBrwx8YQ/HkYVQFS8ke
 - Opening HRMP channels to system parachains: https://docs.polkadot.com/tutorials/interoperability/xcm-channels/para-to-system/
+
+**SORA Polkadot Milestones**
+
+- **Objective**: Move DOT reserve handling from the Polkadot Relay Chain to Polkadot Asset Hub (Statemint) as of [runtimes v2.0.2](https://github.com/polkadot-fellows/runtimes/releases/tag/v2.0.2), open HRMP to Asset Hub, and validate staking/compatibility fixes introduced in that release.
+
+**Phase 1: Analysis & Design**
+
+- **Inventory**: Audit `runtime/src/xcm_config.rs` to ensure `DotFromAssetHub` mirrors the new `AssetHubNativeAsset` guard, `IsReserve` trusts Asset Hub, and `LocalAssetTransactor`/`SAFE_XCM_VERSION` remain aligned with Polkadot (XCM v3).
+- **Target reserve**: Use Polkadot Asset Hub (`ParaId 1000`, `statemint-2000002`) as the reserve location for DOT; stop accepting Relay-only reserves.
+- **Bridging impact**: Confirm bridge pallets (`BeefyLightClient`, `substrate_bridge_channel`, `XCMApp`) do not assume relay-resident DOT balances.
+
+**Phase 2: Runtime Change**
+
+- **Asset guard**: Include `DotFromAssetHub` in the Polkadot `Reserves` tuple so relay-native DOT is only trusted when the reserve location resolves to Asset Hub paths (`X1`, `X2`, `X3` junctions that terminate at Parachain 1000 / GeneralIndex(0)).
+- **Version bump**: Increment `spec_version` for the Polkadot build so governance can enact the upgrade and wallets pick up the DOT reserve migration.
+- **Release alignment**: Track Statemint `core_version statemint-2000002` for compatibility; ensure metadata/extrinsics remain V14 so parachain messaging to Asset Hub 2.0.2 succeeds.
+
+**Phase 3: Testing**
+
+- **Unit/XCM tests**: Extend `runtime/src/xcm_tests` with `dot_from_asset_hub_reserve_rule` covering relay-native DOT, canonical Asset Hub IDs, and reserve location guards.
+- **try-runtime**: Run `cargo try-runtime --features polkadot on-runtime-upgrade` with a recent SORA Polkadot state snapshot to verify storage invariants.
+- **Asset Hub handshake**: Dry-run DOT reserve transfers using `orml_xtokens` + XCM simulator to confirm `IsReserve` accepts Asset Hub DOT and rejects Relay-only DOT.
+
+**Phase 4: Governance & Upgrade**
+
+- **Preimage**: Submit the new Wasm that includes `DotFromAssetHub` + spec bump as a democracy preimage on SORA Polkadot.
+- **Referendum**: Launch democracy proposal (minimum deposit 1 XOR) and schedule enactment. Use Council/Technical Committee fast-track if Asset Hub alignment is urgent.
+- **Communication**: Announce Asset Hub migration timeline to wallets/exchanges so DOT routes shift away from Relay sovereign accounts.
+
+**Phase 5: HRMP to Asset Hub (Polkadot)**
+
+- **Channel open**: From SORA Polkadot (para 2025), send a single XCM to the Relay requesting `hrmp.initOpenChannel(para=1000, max_capacity=<tuned>, max_message_size=1_048_576)`. System parachains auto-accept.
+- **Funding**: Use `scripts/hrmp/open_to_asset_hub.ts --relay-ws wss://rpc.polkadot.io --para 1000 ...` to build the WithdrawAsset → BuyExecution → Transact flow with DOT fees. Set `BuyExecution.fees` to ≥2× the relay estimate.
+- **Verification**: Watch `hrmpAcceptedChannel` events on both Asset Hub and SORA Polkadot; confirm `XcmpQueue` reports the channel as `Open`.
+
+**Phase 6: Sovereign DOT Move**
+
+- **Withdraw & deposit**: From Root, send an XCM to the Relay withdrawing DOT from SORA’s sovereign relay account and depositing it into the Asset Hub sovereign location. Include Asset Hub `BuyExecution` and proof-size limits sized per Statemint 2.0.2 guidance.
+- **Accounting**: After migration, verify the Relay sovereign account is near-zero while the Asset Hub sovereign account holds the DOT reserve used for reserve transfers.
+
+**Phase 7: Compatibility & Apps**
+
+- **Staking & deposits**: Re-test DOT staking flows that rely on Statemint 2.0.2 fixes (invulnerable deposit, XCM staking) to ensure SORA-origin messages succeed.
+- **Wallets/UI**: Update explorers and wallets to fetch DOT balances from Asset Hub rather than Relay accounts; highlight Asset Hub runtime hash `0xe2af694d7e9f890e...` for monitoring.
+- **Monitoring**: Track HRMP queues, XCM `VersionNotifiers`, and Statemint runtime upgrades so SORA Polkadot stays in sync with new releases.
+
+**Phase 8: Timeline**
+
+- **T0**: Runtime diff + try-runtime validated.
+- **T0 + 1w**: Governance submission + communications.
+- **T0 + 2w**: Runtime enactment, HRMP open, sovereign DOT move.
+- **Post**: Audit + docs update; plan for next Statemint release if required.

--- a/MILESTONES.md
+++ b/MILESTONES.md
@@ -114,6 +114,13 @@
 - **Funding**: Use `scripts/hrmp/open_to_asset_hub.ts --relay-ws wss://rpc.polkadot.io --para 1000 ...` to build the WithdrawAsset → BuyExecution → Transact flow with DOT fees. Set `BuyExecution.fees` to ≥2× the relay estimate for any future channel adjustments.
 - **Monitoring**: Continue watching `hrmp.hrmpChannels([2025,1000])` and Asset Hub events to ensure throughput/limits remain aligned with demand.
 
+**Phase 5b: HRMP to Coretime (Polkadot) for Auto-Renewal**
+
+- **Objective**: Mirror the Kusama flow by opening a channel from SORA Polkadot (para 2025) to the Polkadot Coretime system parachain (check chain state; currently para 1001) so the automatic coretime renewal process described in [the Coretime guide](https://docs.polkadot.com/develop/parachains/deployment/coretime-renewal/) can operate over HRMP.
+- **Channel request**: Use the HRMP helper with `--para <coretime_para_id>` to send `hrmp.initOpenChannel` (capacity 1000, message size 1_048_576) from Root. System parachains auto-accept; ensure DOT fees are withdrawn via WithdrawAsset + BuyExecution.
+- **Renewal workflow**: After the channel opens, follow the Coretime renewal guide to (a) configure the renewal pallet on SORA Polkadot, (b) fund the Coretime parachain account for periodic purchases, and (c) monitor renewal status via `coretimeAssignments` RPCs.
+- **Monitoring**: Periodically query `hrmp.hrmpChannels([2025,<coretime_para_id>])` and the Coretime chain’s events to confirm execution capacity remains within headroom; schedule governance follow-ups if capacity increases are required.
+
 **Phase 6: Sovereign DOT Move**
 
 - **Withdraw & deposit**: From Root, send an XCM to the Relay withdrawing DOT from SORA’s sovereign relay account and depositing it into the Asset Hub sovereign location. Include Asset Hub `BuyExecution` and proof-size limits sized per Statemint 2.0.2 guidance.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -221,7 +221,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
     spec_name: create_runtime_str!("sora_ksm"),
     impl_name: create_runtime_str!("sora_ksm"),
     authoring_version: 1,
-    spec_version: 15,
+    spec_version: 16,
     impl_version: 0,
     apis: RUNTIME_API_VERSIONS,
     transaction_version: 14,

--- a/runtime/src/xcm_config.rs
+++ b/runtime/src/xcm_config.rs
@@ -164,7 +164,7 @@ impl xcm_executor::Config for XcmConfig {
     type AssetTransactor = LocalAssetTransactor;
     type OriginConverter = XcmOriginToTransactDispatchOrigin;
     // Reserve locations the chain trusts.
-    // Keep native reserves via MultiNativeAsset and explicitly trust KSM from Kusama Asset Hub.
+    // Keep native reserves via MultiNativeAsset and explicitly trust Asset Hub-backed relay assets.
     type IsReserve = Reserves;
     type IsTeleporter = (); // Teleporting is disabled.
     type Barrier = Barrier;
@@ -199,52 +199,56 @@ pub type XcmRouter = (
     XcmpQueue,
 );
 
-// Allow relay-native KSM (parents:1, Here) when the reserve location is Kusama Asset Hub (para 1000).
-pub struct KsmFromAssetHub;
-impl ContainsPair<MultiAsset, MultiLocation> for KsmFromAssetHub {
+// Allow relay-native assets (parents:1, Here) whose reserve has migrated to Asset Hub.
+pub struct AssetHubNativeAsset<const PARA_ID: u32>;
+impl<const PARA_ID: u32> ContainsPair<MultiAsset, MultiLocation> for AssetHubNativeAsset<PARA_ID> {
     fn contains(asset: &MultiAsset, location: &MultiLocation) -> bool {
-        // KSM may appear as relay-native (parents:1, Here) while reserve migrates to Asset Hub,
-        // or be encoded canonically under Asset Hub as GeneralIndex(0) (optionally with PalletInstance(50)).
-        // Accept either concrete ID, but only when the reserve location indicates Asset Hub (para 1000).
-        let is_ksm =
-            matches!(
-                asset,
-                MultiAsset { id: Concrete(MultiLocation { parents: 1, interior: Here }), fun: Fungible(_) }
-            ) ||
-            matches!(
-                asset,
-                MultiAsset { id: Concrete(MultiLocation { parents: 1, interior: X2(Parachain(1000), GeneralIndex(0)) }), fun: Fungible(_) }
-            ) ||
-            matches!(
-                asset,
-                MultiAsset { id: Concrete(MultiLocation { parents: 1, interior: X3(Parachain(1000), PalletInstance(50), GeneralIndex(0)) }), fun: Fungible(_) }
-            );
-        let is_from_asset_hub =
-            // Parachain-only path (some contexts may provide this)
-            matches!(
-                location,
-                MultiLocation { parents: 1, interior: X1(Parachain(1000)) }
-            ) ||
-            // Canonical Asset Hub reserve paths for KSM
-            matches!(
-                location,
-                MultiLocation { parents: 1, interior: X2(Parachain(1000), GeneralIndex(0)) }
-            ) ||
-            matches!(
-                location,
-                MultiLocation { parents: 1, interior: X3(Parachain(1000), PalletInstance(50), GeneralIndex(0)) }
-            );
-        is_ksm && is_from_asset_hub
+        // Assets may appear as relay-native (parents:1, interior:Here) while reserves move, or be
+        // encoded canonically under Asset Hub as GeneralIndex(0) optionally wrapped by PalletInstance(50).
+        let is_native = match asset {
+            MultiAsset { id: Concrete(loc), fun: Fungible(_) } => {
+                let loc = loc.clone();
+                match loc {
+                    MultiLocation { parents: 1, interior } => match interior {
+                        Here => true,
+                        X2(Parachain(id), GeneralIndex(0)) if id == PARA_ID => true,
+                        X3(Parachain(id), PalletInstance(50), GeneralIndex(0)) if id == PARA_ID =>
+                            true,
+                        _ => false,
+                    },
+                    _ => false,
+                }
+            },
+            _ => false,
+        };
+        let is_from_asset_hub = match location.clone() {
+            MultiLocation { parents: 1, interior } => match interior {
+                X1(Parachain(id)) if id == PARA_ID => true,
+                X2(Parachain(id), GeneralIndex(0)) if id == PARA_ID => true,
+                X3(Parachain(id), PalletInstance(50), GeneralIndex(0)) if id == PARA_ID => true,
+                _ => false,
+            },
+            _ => false,
+        };
+        is_native && is_from_asset_hub
     }
 }
 
+pub type KsmFromAssetHub = AssetHubNativeAsset<1000>;
+pub type DotFromAssetHub = AssetHubNativeAsset<1000>;
+
 // Union of trusted reserve resolvers.
-pub type Reserves = (
-    // Native assets whose absolute reserve is local
-    MultiNativeAsset<AbsoluteReserveProvider>,
-    // KSM with reserve on Kusama Asset Hub
-    KsmFromAssetHub,
-);
+#[cfg(all(feature = "kusama", feature = "polkadot"))]
+pub type Reserves = (MultiNativeAsset<AbsoluteReserveProvider>, KsmFromAssetHub, DotFromAssetHub);
+
+#[cfg(all(feature = "kusama", not(feature = "polkadot")))]
+pub type Reserves = (MultiNativeAsset<AbsoluteReserveProvider>, KsmFromAssetHub);
+
+#[cfg(all(feature = "polkadot", not(feature = "kusama")))]
+pub type Reserves = (MultiNativeAsset<AbsoluteReserveProvider>, DotFromAssetHub);
+
+#[cfg(not(any(feature = "kusama", feature = "polkadot")))]
+pub type Reserves = MultiNativeAsset<AbsoluteReserveProvider>;
 
 #[cfg(feature = "runtime-benchmarks")]
 parameter_types! {

--- a/runtime/src/xcm_tests/tests.rs
+++ b/runtime/src/xcm_tests/tests.rs
@@ -29,16 +29,20 @@
 // USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use super::*;
+#[cfg(feature = "polkadot")]
+use crate::xcm_config::DotFromAssetHub;
+use crate::xcm_config::KsmFromAssetHub;
 use bridge_types::{
     substrate::ParachainAppCall, traits::OutboundChannel, GenericTimepoint, SubNetworkId,
 };
 use cumulus_primitives_core::ParaId;
-use frame_support::{assert_ok, traits::Currency};
+use frame_support::{
+    assert_ok,
+    traits::{ContainsPair, Currency},
+};
 use orml_traits::MultiCurrency;
 use sp_runtime::{traits::AccountIdConversion, AccountId32};
 use xcm_simulator::TestExt;
-use crate::xcm_config::KsmFromAssetHub;
-use frame_support::traits::ContainsPair;
 
 fn para_x_account() -> AccountId32 {
     ParaId::from(1).into_account_truncating()
@@ -73,13 +77,37 @@ fn ksm_from_asset_hub_reserve_rule() {
     // Location is Relay (parents=1, Here)
     let relay_loc = MultiLocation::new(1, Here);
     // Non-fungible asset (should be rejected regardless)
-    let nft_like = MultiAsset { id: Concrete(MultiLocation::new(1, Here)), fun: NonFungible(AssetInstance::Index(1)) };
+    let nft_like = MultiAsset {
+        id: Concrete(MultiLocation::new(1, Here)),
+        fun: NonFungible(AssetInstance::Index(1)),
+    };
 
     assert!(KsmFromAssetHub::contains(&ksm, &ah_loc));
     assert!(KsmFromAssetHub::contains(&ksm, &ah_loc_x2));
     assert!(KsmFromAssetHub::contains(&ksm, &ah_loc_x3));
     assert!(!KsmFromAssetHub::contains(&ksm, &relay_loc));
     assert!(!KsmFromAssetHub::contains(&nft_like, &ah_loc));
+}
+
+#[cfg(feature = "polkadot")]
+#[test]
+fn dot_from_asset_hub_reserve_rule() {
+    // DOT assets mirror KSM reserve rules but target Polkadot Asset Hub.
+    let dot = MultiAsset { id: Concrete(MultiLocation::new(1, Here)), fun: Fungible(500) };
+    let ah_loc = MultiLocation::new(1, X1(Parachain(1000)));
+    let ah_loc_x2 = MultiLocation::new(1, X2(Parachain(1000), GeneralIndex(0)));
+    let ah_loc_x3 = MultiLocation::new(1, X3(Parachain(1000), PalletInstance(50), GeneralIndex(0)));
+    let relay_loc = MultiLocation::new(1, Here);
+    let nft_like = MultiAsset {
+        id: Concrete(MultiLocation::new(1, Here)),
+        fun: NonFungible(AssetInstance::Index(1)),
+    };
+
+    assert!(DotFromAssetHub::contains(&dot, &ah_loc));
+    assert!(DotFromAssetHub::contains(&dot, &ah_loc_x2));
+    assert!(DotFromAssetHub::contains(&dot, &ah_loc_x3));
+    assert!(!DotFromAssetHub::contains(&dot, &relay_loc));
+    assert!(!DotFromAssetHub::contains(&nft_like, &ah_loc));
 }
 
 fn relay_native_asset_id() -> crate::H256 {

--- a/scripts/hrmp/README.md
+++ b/scripts/hrmp/README.md
@@ -1,9 +1,9 @@
 HRMP Open Channel Helper
 
-This script builds an XCM v3 message to open an HRMP channel from SORA Kusama (para 2011) to Kusama Asset Hub (para 1000) by executing `hrmp.initOpenChannel` on the Relay (Parent) via `Transact`.
+This script builds an XCM v3 message to open an HRMP channel from a SORA parachain (Kusama para 2011 or Polkadot para 2025) to its Asset Hub (para 1000) by executing `hrmp.initOpenChannel` on the Relay (Parent) via `Transact`.
 
 Key points (security + compatibility):
-- WithdrawAsset + BuyExecution: The XCM includes `WithdrawAsset` and `BuyExecution` before `Transact` so the Relay has fees to execute the call. Fees are withdrawn as KSM from SORA’s sovereign account on the Relay (`parents: 1, interior: Here`). Ensure this account holds sufficient KSM.
+- WithdrawAsset + BuyExecution: The XCM includes `WithdrawAsset` and `BuyExecution` before `Transact` so the Relay has fees to execute the call. Fees are withdrawn as the relay-native asset (KSM for Kusama, DOT for Polkadot) from SORA’s sovereign account on the Relay (`parents: 1, interior: Here`). Ensure this account holds sufficient funds.
 - Dynamic weight: `Transact.requireWeightAtMost` is derived from `paymentInfo(...).weight.refTime` (WeightV2) for the relay runtime to avoid `WeightNotEnough` on upgrades. You can tune with `--weight-multiplier`.
 - Fee selection: By default the script multiplies the Relay fee estimate by `--fee-multiplier` (default `2.0`) and encodes that amount into `BuyExecution.fees`. You can override with `--fee-plancks`.
 
@@ -17,6 +17,14 @@ Usage (build payload only):
     [--fee-plancks 20000000000 | --fee-multiplier 2.0] \
     [--weight-multiplier 1.2]
 
+  TS_NODE_TRANSPILE_ONLY=1 ts-node scripts/hrmp/open_to_asset_hub.ts \
+    --relay-ws wss://rpc.polkadot.io \
+    --sora-ws wss://polkadot.sora.org \
+    --para 1000 --capacity 1000 --messageSize 1048576 \
+    --relay-symbol DOT --relay-decimals 10 \
+    [--fee-plancks 20000000000 | --fee-multiplier 2.0] \
+    [--weight-multiplier 1.2]
+
 Usage (submit on SORA, if permitted):
 
   TS_NODE_TRANSPILE_ONLY=1 ts-node scripts/hrmp/open_to_asset_hub.ts \
@@ -26,6 +34,8 @@ Usage (submit on SORA, if permitted):
     [--fee-plancks 20000000000 | --fee-multiplier 2.0] \
     [--weight-multiplier 1.2] \
     --seed "//Alice" --submit
+
+Use `--relay-symbol DOT --relay-decimals 10` when operating against Polkadot so fee estimates display DOT units (defaults `KSM` / `12` decimals).
 
 Dry-run fee estimate (no extrinsic built):
 
@@ -42,5 +52,5 @@ Message template (XCM v3):
   - `Transact`: `{ originKind: 'Native', requireWeightAtMost: { refTime: <derived>, proofSize: <derived> }, call: { encoded: <hrmp.initOpenChannel call> } }`
 
 Operational notes:
-- Ensure the SORA sovereign account on Kusama holds enough KSM to cover `BuyExecution.fees`.
+- Ensure the SORA sovereign account on the Relay holds enough native tokens (KSM/DOT) to cover `BuyExecution.fees`.
 - If Relay weight or fees change due to runtime upgrades, adjust `--fee-multiplier` or pass `--fee-plancks` explicitly. The script already derives weight to avoid hard-coded caps.

--- a/scripts/hrmp/open_to_asset_hub.ts
+++ b/scripts/hrmp/open_to_asset_hub.ts
@@ -1,6 +1,6 @@
 /*
-Build an XCM (v3) to open an HRMP channel from SORA Kusama (para 2011)
-to Kusama Asset Hub (para 1000) by sending a Transact to the Relay.
+Build an XCM (v3) to open an HRMP channel from a SORA parachain (Kusama para 2011
+or Polkadot para 2025) to Asset Hub (para 1000) by sending a Transact to the Relay.
 
 Fixes per security review:
 - Add WithdrawAsset + BuyExecution before Transact so execution is funded on the Relay.
@@ -31,8 +31,9 @@ Usage (submit on SORA, if permitted):
     --seed "//Alice" --submit
 
 Notes:
-- Fees are paid with KSM withdrawn from SORA’s sovereign account on the Relay (parents:1, interior:Here).
-  Ensure that sovereign account holds enough KSM before sending.
+- Fees are paid with the relay-native asset (KSM on Kusama, DOT on Polkadot) withdrawn from
+  SORA’s sovereign account on the Relay (parents:1, interior:Here). Ensure that sovereign
+  account holds enough balance before sending.
 - Use --estimate to print fee estimates from the Relay without building a call.
 */
 
@@ -58,6 +59,8 @@ async function main() {
   const feePlancksArg = process.argv.includes('--fee-plancks') ? BigInt(arg('--fee-plancks')) : undefined;
   const feeMultiplier = Number(arg('--fee-multiplier', '2.0'));
   const weightMultiplier = Number(arg('--weight-multiplier', '1.2'));
+  const relaySymbol = arg('--relay-symbol', 'KSM');
+  const relayDecimals = Number(arg('--relay-decimals', '12'));
 
   // 1) Build Relay call: hrmp.initOpenChannel(dest, capacity, messageSize)
   const relayApi = await ApiPromise.create({ provider: new WsProvider(relayWs) });
@@ -75,8 +78,9 @@ async function main() {
   const proofSize = estWeight?.proofSize ? BigInt(estWeight.proofSize.toString()) : BigInt(0);
 
   if (estimate) {
-    const ksm = Number(rawFeePlancks) / 1e12;
-    console.log(`Estimated relay fee (no tip): ${rawFeePlancks.toString()} plancks (~${ksm} KSM)`);
+    const divisor = Number.isFinite(relayDecimals) ? Math.pow(10, relayDecimals) : 1;
+    const human = divisor > 0 ? Number(rawFeePlancks) / divisor : Number(rawFeePlancks);
+    console.log(`Estimated relay fee (no tip): ${rawFeePlancks.toString()} plancks (~${human} ${relaySymbol})`);
     console.log(`Estimated weight: refTime=${refTime.toString()}, proofSize=${proofSize.toString()}`);
     console.log(`Recommendation: set BuyExecution.fees to at least ${feeMultiplier}x this estimate and weight multiplier ~${weightMultiplier}.`);
     await relayApi.disconnect();


### PR DESCRIPTION
## Changes

- Added a generic AssetHubNativeAsset guard and DotFromAssetHub alias so Polkadot builds only trust DOT whose reserve resolves to Asset Hub (mirroring the Kusama logic); bumped the Polkadot runtime spec_version and extended the XCM tests with dot_from_asset_hub_reserve_rule.
- Documented the new reserve strategy and upgrade plan across the guide/ milestones, detailing governance, HRMP, and sovereign-account steps for the DOT migration.
- Updated the HRMP helper (code + README) to support both Kusama and Polkadot, including configurable relay symbols/decimals for fee estimation.

# Tests

- PROTOC=/opt/homebrew/bin/protoc cargo test -p sora2-parachain-runtime --features polkadot dot_from_asset_hub_reserve_rule